### PR TITLE
Add `holes` features

### DIFF
--- a/ocaml-eglot-request.el
+++ b/ocaml-eglot-request.el
@@ -99,5 +99,10 @@
   (let ((params (ocaml-eglot-req--SearchParams query limit)))
     (ocaml-eglot-req--send :ocamllsp/typeSearch params)))
 
+(defun ocaml-eglot-req--holes ()
+  "Returns a list of all the typed holes in the document as an range list."
+  (let ((params (ocaml-eglot-req--TextDocumentIdentifier)))
+    (append (ocaml-eglot-req--send :ocamllsp/typedHoles params) nil)))
+
 (provide 'ocaml-eglot-request)
 ;;; ocaml-eglot-request ends here

--- a/ocaml-eglot-util.el
+++ b/ocaml-eglot-util.el
@@ -41,6 +41,29 @@
   "Moves the cursor to a position calculated by LSP."
   (goto-char (eglot--lsp-position-to-point lsp-position)))
 
+(defun ocaml-eglot-util--jump-to-range (lsp-range)
+  "Moves the cursor to the start of a range calculated by LSP."
+  (let ((start (cl-getf lsp-range :start)))
+    (goto-char (eglot--lsp-position-to-point start))))
+
+(defun ocaml-eglot-util--compare-position (a b)
+  "Comparison between two LSP positions."
+  (let ((char-a (cl-getf a :character))
+        (char-b (cl-getf b :character))
+        (line-a (cl-getf a :line))
+        (line-b (cl-getf b :line)))
+    (if (> line-a line-b) 1
+      (if (> line-b line-a) -1
+        (if (> char-a char-b) 1
+          (if (> char-b char-a) -1 0))))))
+
+(defun ocaml-eglot-util--position-increase-char (pos content)
+  "Calculates a new position after inserting text content."
+  (let* ((line (cl-getf pos :line))
+         (character (cl-getf pos :character))
+         (new-char (+ character (length content))))
+    `(:line ,line :character ,new-char)))
+
 ;; Jump features
 
 (defun ocaml-eglot-util--extract-jump-position (jump-result)
@@ -49,8 +72,6 @@
     (when (> (length target-vec) 0)
       (let ((real-target (aref target-vec 0)))
         (cl-getf real-target :position)))))
-
-;; Search by types utils
 
 (provide 'ocaml-eglot-util)
 ;;; ocaml-eglot-util ends here

--- a/ocaml-eglot.el
+++ b/ocaml-eglot.el
@@ -103,6 +103,7 @@ If there is not valid hole, the first hole of the list is returned."
 (defun ocaml-eglot-prev-hole ()
   "Jump to the previous hole."
   (interactive)
+  (eglot--server-capable-or-lose :experimental :ocamllsp :handleTypedHoles)
   (let* ((current-pos (eglot--pos-to-lsp-position))
          (holes (reverse (ocaml-eglot-req--holes)))
          (hole (ocaml-eglot--first-hole-at holes current-pos '<)))
@@ -111,6 +112,7 @@ If there is not valid hole, the first hole of the list is returned."
 (defun ocaml-eglot-next-hole ()
   "Jump to the next hole."
   (interactive)
+  (eglot--server-capable-or-lose :experimental :ocamllsp :handleTypedHoles)
   (let* ((current-pos (eglot--pos-to-lsp-position))
          (holes (ocaml-eglot-req--holes))
          (hole (ocaml-eglot--first-hole-at holes current-pos '>)))

--- a/ocaml-eglot.el
+++ b/ocaml-eglot.el
@@ -67,6 +67,54 @@ Otherwise, `merlin-construct' only includes constructors."
   (interactive)
   (flymake-goto-prev-error))
 
+;; Holes
+
+;; TODO: It would probably be possible to improve the query to embed
+;; more logic at the `merlin-lib` level rather than calculating hole
+;; logic at the editor level.
+
+(defun ocaml-eglot--first-hole-aux (holes pos comparison)
+  "Returns the first HOLE of the list according to a comparison predicate."
+  (when (or holes (> 0 (length holes)))
+    (let* ((hd (car holes))
+           (tl (cdr holes))
+           (h-start (cl-getf hd :start))
+           (cmp (ocaml-eglot-util--compare-position h-start pos)))
+      (if (funcall comparison cmp 0) hd
+        (ocaml-eglot--first-hole-aux tl pos comparison)))))
+
+(defun ocaml-eglot--first-hole-at (holes pos comparison)
+  "Returns the first HOLE of the list according to a comparison predicate.
+If there is not valid hole, the first hole of the list is returned."
+  (let ((hole (ocaml-eglot--first-hole-aux holes pos comparison)))
+    (if hole hole (car holes))))
+
+(defun ocaml-eglot--first-hole-in (start end)
+  "Jump to the first hole in a given range."
+  (let* ((holes (ocaml-eglot-req--holes))
+         (hole (ocaml-eglot--first-hole-at holes start '>)))
+    (when hole
+      (let ((hole-start (cl-getf hole :start))
+            (hole-end (cl-getf hole :end)))
+        (when (and (>= (ocaml-eglot-util--compare-position hole-start start) 0)
+                   (<= (ocaml-eglot-util--compare-position hole-end end) 0))
+          (progn (ocaml-eglot-util--jump-to hole-start)))))))
+
+(defun ocaml-eglot-prev-hole ()
+  "Jump to the previous hole."
+  (interactive)
+  (let* ((current-pos (eglot--pos-to-lsp-position))
+         (holes (reverse (ocaml-eglot-req--holes)))
+         (hole (ocaml-eglot--first-hole-at holes current-pos '<)))
+    (when hole (ocaml-eglot-util--jump-to-range hole))))
+
+(defun ocaml-eglot-next-hole ()
+  "Jump to the next hole."
+  (interactive)
+  (let* ((current-pos (eglot--pos-to-lsp-position))
+         (holes (ocaml-eglot-req--holes))
+         (hole (ocaml-eglot--first-hole-at holes current-pos '>)))
+    (when hole (ocaml-eglot-util--jump-to-range hole))))
 
 ;; Jump to source elements
 
@@ -104,13 +152,18 @@ can be used to change the maximim number of result."
          (suggestions (append (cl-getf result :result) nil)))
     (when (= (length suggestions) 0)
       (eglot--error "No constructors for this hole"))
-    (cl-labels ((insert-construct-choice (subst)
-                  ;; TODO: Move to the next hole in the generated text
-                  (ocaml-eglot-util--replace-region range subst)))
+    (cl-labels
+        ((insert-construct-choice (subst)
+           (let* ((start (cl-getf range :start))
+                  (end (ocaml-eglot-util--position-increase-char
+                        start subst)))
+             (ocaml-eglot-util--replace-region range subst)
+             (ocaml-eglot--first-hole-in start end))))
       (if (= (length suggestions) 1)
           (insert-construct-choice (car suggestions))
         (let ((choice (completing-read "Constructor: " suggestions nil t)))
           (insert-construct-choice choice))))))
+
 
 ;;; Mode
 


### PR DESCRIPTION
Implementation of typical holes (navigation via
`ocaml-eglot-next-hole` and `ocaml-eglot-prev-hole`) and use of holes in `construct`.