### PR TITLE
Display the error when jump en prev/next error

### DIFF
--- a/ocaml-eglot.el
+++ b/ocaml-eglot.el
@@ -93,12 +93,12 @@ Otherwise, `merlin-construct' only includes constructors."
 (defun ocaml-eglot-error-next ()
   "Jump to the next error."
   (interactive)
-  (flymake-goto-next-error))
+  (call-interactively #'flymake-goto-next-error))
 
 (defun ocaml-eglot-error-prev ()
   "Jump to the previous error."
   (interactive)
-  (flymake-goto-prev-error))
+  (call-interactively #'flymake-goto-prev-error))
 
 ;; Jump to definition
 


### PR DESCRIPTION
For the moment, jumping to the next or previous error did not display the error we had jumped to. By calling the flymake functions interactively, the error is correctly reported.