### PR TITLE
Add `ocaml-eglot-phrase-prev/next` (using merlinCall)

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,10 @@ provided:
 
 - `ocaml-eglot-find-type-definition-in-new-window`
 - `ocaml-eglot-find-type-definition-in-current-window`
+- `ocaml-eglot-phrase-prev` (<kbd>C-c</kbd> <kbd>C-p</kbd>): jump to
+  the beginning of the previous phrase
+- `ocaml-eglot-phrase-next` (<kbd>C-c</kbd> <kbd>C-n</kbd>): jump to
+  the beginning of the next phrase
 
 ### Find occurences
 

--- a/ocaml-eglot-req.el
+++ b/ocaml-eglot-req.el
@@ -184,5 +184,22 @@ VERBOSITY is a potential verbosity index."
   (let ((action-kind "destruct (enumerate cases)"))
     (ocaml-eglot-req--call-code-action action-kind)))
 
+(defun ocaml-eglot-req--merlin-call (command argv)
+  "Use tunneling `ocamllsp/merlinCallCompatible'.
+COMMAND is the command of the Merlin Protocol.
+ARGV is the list of arguments."
+  (let ((params (append (ocaml-eglot-req--TextDocumentIdentifier)
+                        `(:command, command)
+                        `(:resultAsSexp, :json-false)
+                        `(:args, argv))))
+    (ocaml-eglot-req--send :ocamllsp/merlinCallCompatible params)))
+
+(defun ocaml-eglot-req--phrase (target)
+  "Compute the beginning of the phrase referenced by TARGET."
+  ; TODO: use a dedicated custom request instead of tunneling
+  (let ((argv (vector "-position" (ocaml-eglot-util-point-as-arg (point))
+                      "-target" target)))
+    (ocaml-eglot-req--merlin-call "phrase" argv)))
+
 (provide 'ocaml-eglot-req)
 ;;; ocaml-eglot-req.el ends here

--- a/ocaml-eglot.el
+++ b/ocaml-eglot.el
@@ -326,6 +326,27 @@ If there is no available holes, it returns the first one of HOLES."
           (ocaml-eglot-util--jump-to position)
         (eglot--error "Target not found")))))
 
+(defun ocaml-eglot--phrase (direction)
+  "Move to the next or previous phrase using DIRECTION."
+  (let* ((result (ocaml-eglot-req--phrase direction))
+         (json-result (ocaml-eglot-util--merlin-call-result result))
+         (pos (cl-getf json-result :pos)))
+    (when pos
+      (let* ((line (cl-getf pos :line))
+             (col (cl-getf pos :col))
+             (target (ocaml-eglot-util--point-by-pos line col)))
+        (ocaml-eglot-util--goto-char target)))))
+
+(defun ocaml-eglot-phrase-next ()
+  "Go to the beginning of the next phrase."
+  (interactive)
+  (ocaml-eglot--phrase "next"))
+
+(defun ocaml-eglot-phrase-prev ()
+  "Go to the beginning of the previous phrase."
+  (interactive)
+  (ocaml-eglot--phrase "prev"))
+
 ;; Search by type or polarity
 
 (defun ocaml-eglot--search-as-key (value-name value-type value-doc)
@@ -485,6 +506,8 @@ If called repeatedly, increase the verbosity of the type shown."
     (define-key ocaml-eglot-keymap (kbd "C-c C-t") #'ocaml-eglot-type-enclosing)
     (define-key ocaml-eglot-keymap (kbd "C-c |") #'ocaml-eglot-destruct)
     (define-key ocaml-eglot-keymap (kbd "C-c \\") #'ocaml-eglot-construct)
+    (define-key ocaml-eglot-keymap (kbd "C-c C-p") #'ocaml-eglot-phrase-prev)
+    (define-key ocaml-eglot-keymap (kbd "C-c C-n") #'ocaml-eglot-phrase-next)
     ocaml-eglot-keymap)
   "Keymap for OCaml-eglot minor mode.")
 


### PR DESCRIPTION
As the navigation functions between sentences are not accessible via queries, this implementation relies on tunneling.