### PR TITLE
Capitalise mode's display name

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+ocaml-eglot unreleased
+======================
+
+- Made the mode-line "lighter" more conventional ([#26](https://github.com/tarides/ocaml-eglot/pull/26))
+
 ocaml-eglot 1.0.0
 =================
 Fri Jan 17 04:50:35 PM CET 2025

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ocaml-eglot
+# OCaml-eglot
 
 **`ocaml-eglot`** is a lightweight
 [Emacs](https://www.gnu.org/software/emacs/) **minor mode** designed

--- a/ocaml-eglot.el
+++ b/ocaml-eglot.el
@@ -543,7 +543,7 @@ and print its type."
   "Minor mode for interacting with `ocaml-lsp-server' using `eglot' as a client.
 `ocaml-eglot' provides standard implementations of the various custom-requests
  exposed by `ocaml-lsp-server'."
-  :lighter " ocaml-eglot"
+  :lighter " OCaml-eglot"
   :keymap ocaml-eglot-map
   :group 'ocaml-eglot
   (add-hook 'find-file-hook #'ocaml-eglot--file-hook))


### PR DESCRIPTION
It's conventional for a mode's display name to be capitalised. At the moment, it looks weird to have a component of the mode-line be all-lowercase 😅