### PR TITLE
Require flycheck optionally for people who don't have installed it

### DIFF
--- a/ocaml-eglot.el
+++ b/ocaml-eglot.el
@@ -33,7 +33,7 @@
 ;;; Code:
 
 (require 'flymake)
-(require 'flycheck)
+(require 'flycheck nil 'noerror)
 (require 'xref)
 (require 'cl-lib)
 (require 'ocaml-eglot-util)


### PR DESCRIPTION
My package-upgrade of ocaml-eglot failed because I don't have flycheck installed. This patch fixes it.