### PR TITLE
Kill the last two byte compilation warnings

### DIFF
--- a/ocaml-eglot.el
+++ b/ocaml-eglot.el
@@ -41,6 +41,9 @@
 (require 'ocaml-eglot-type-enclosing)
 (require 'eglot)
 
+(declare-function flycheck-next-error "ext:flycheck")
+(declare-function flycheck-previous-error "ext:flycheck")
+
 (defgroup ocaml-eglot nil
   "All interactions from Eglot to OCaml-lsp-server."
   :link '(url-link "https://ocaml.org")


### PR DESCRIPTION
This patch kills the last two byte compilation warnings saying that flycheck-next-error and flycheck-previous-error are not defined. 