### PR TITLE
README.md: fix some typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ interface between `eglot` (available _out of the box_ since `emacs >=
 installed (e.g. [caml-mode](https://melpa.org/#/caml) or
 [tuareg](https://melpa.org/#/tuareg)). Then, for example, you can use
 [`use-package`](https://www.gnu.org/software/emacs/manual/html_node/use-package/Lisp-Configuration.html)
-to install OCaml-eglot. You will also need
+to install `ocaml-eglot`. You will also need
 `https://ocaml.org/p/ocaml-lsp-server/latest` in the [current
 switch](https://ocaml.org/docs/opam-switch-introduction).
 
@@ -76,7 +76,7 @@ Eglot provides a hook to format the buffer on saving:
 
 Eglot introduces a lot of visual noise (which can greatly alter the
 user experience, especially when you're from `merlin`). One way of
-reducing this visual obtrusion is to disable type anotations (`eldoc`)
+reducing this visual obtrusion is to disable type annotations (`eldoc`)
 and `inlay-hints`:
 
 ```diff
@@ -126,7 +126,7 @@ configuration in this way:
 OCaml-lsp-server can use `.merlin` as a configuration template (rather
 than configuring via `dune`). This requires the
 [`dot-merlin-reader`](https://ocaml.org/p/dot-merlin-reader/latest)
-package to be installed in the switch being used, and `eglot` can be
+package to be installed in the switch being used, and then `eglot` can be
 configured in this way:
 
 ```diff
@@ -191,7 +191,7 @@ to display the type:
 
 ### Jump to definition/declaration
 
-OCaml-eglot provides a shortcut to quickly jump to the definition or
+`ocaml-eglot` provides a shortcut to quickly jump to the definition or
 declaration of an identifier:
 
 - `ocaml-eglot-find-definition` (<kbd>C-c</kbd> <kbd>C-l</kbd>): jump to
@@ -203,8 +203,8 @@ declaration of an identifier:
 ![Jump to definition example](media/find-def-decl.gif)
 
 The default calculation for the window containing the jump result is
-_smart_: if the target is on the same file, the command uses the same
-window; if the target is on another file, the command opens a new
+_smart_: if the target is in the same file, the command uses the same
+window; if the target is in another file, the command opens a new
 window. Auxiliary functions for controlling the placement of a result
 are provided:
 
@@ -224,7 +224,7 @@ be confusing:
 - `definition`: corresponds to the implementation
 - `declaration`: corresponds to the signature
 
-### Find indentifier definition/declaration
+### Find identifier definition/declaration
 
 It is also possible to directly enter the name of an identifier
 (definition or declaration) using the following commands:
@@ -258,7 +258,7 @@ provided:
 - `ocaml-eglot-phrase-next` (<kbd>C-c</kbd> <kbd>C-n</kbd>): jump to
   the beginning of the next phrase
 
-### Find occurences
+### Find occurrences
 
 `ocaml-eglot-occurences` returns all occurrences of the
 identifier under the cursor. To find all occurrences in the entire
@@ -267,7 +267,7 @@ project, it requires an index. This index can be created by running
 `5.2` and Dune `3.16.0`. See the
 [announcement](https://discuss.ocaml.org/t/ann-project-wide-occurrences-in-merlin-and-lsp/14847/1).
 
-![Occurences example](media/occurences.gif)
+![Occurrences example](media/occurences.gif)
 
 ### Renaming
 
@@ -291,20 +291,20 @@ contents:
 ### Find Alternate file
 
 OCaml-eglot allows you to quickly switch from the implementation file
-to the interface file and _vice versa_. If the interface file does not
+to the interface file and vice versa. If the interface file does not
 exist, a prompt can be used to generate it (using type inference,
-based on `ocaml-eglot-infer-inteface`):
+based on `ocaml-eglot-infer-interface`):
 
 - `ocaml-eglot-alternate-file` (<kbd>C-c</kbd> <kbd>C-a</kbd>): switch
-  from the implementation file to the interface file and _vice versa_
+  from the implementation file to the interface file and vice versa
 
 ![Find Alternate File example](media/alternate-file.gif)
 
 ### Get Documentation
 
 Although the `Hover` primitive in the LSP protocol can be used to
-conveniently display value documentation, it is also possible to query for it
-specifically:
+conveniently display the documentation of a value, it is also possible to query for it
+explicitly:
 
 - `ocaml-eglot-document` (<kbd>C-c</kbd> <kbd>C-d</kbd>): documents
   the expression below the cursor.
@@ -316,8 +316,8 @@ specifically:
 
 ### Construct Expression
 
-Enables you to navigate between the different typed-holes (`_`) in a
-document and interactively substitute them:
+Enables you to navigate between typed-holes (`_`) in a document and
+interactively substitute them:
 
 - `ocaml-eglot-hole-next`: jump to the next hole
 - `ocaml-eglot-hole-prev`: jump to the previous hole
@@ -327,13 +327,13 @@ document and interactively substitute them:
 ![Construct Example](media/construct.gif)
 
 If the `ocaml-eglot-construct` (<kbd>C-c</kbd> <kbd>\\</kbd>) command
-is prefixed by an argument, ie: `C-u M-x ocaml-eglot-construct`, the
+is prefixed by an argument, i.e.: `C-u M-x ocaml-eglot-construct`, the
 command will also search for valid candidates in the current
 environment:
 
 ![Construct with prefix-arg Example](media/construct2.gif)
 
-### Destruct (or case-anlysis)
+### Destruct (or case-analysis)
 
 Destruct, `ocaml-eglot-destruct` (<kbd>C-c</kbd> <kbd>|</kbd>) is a
 powerful feature that allows one to generate and manipulate pattern
@@ -357,7 +357,7 @@ navigate between pattern matching cases:
 
 - `ocaml-eglot-jump`: jumps to the referenced expression
 
-![Construct with prefix-arg Example](media/jump.gif)
+![Source Browsing Example](media/jump.gif)
 
 ### Search for values
 


### PR DESCRIPTION
Here's some small fixes to the README.md.

---

Here are some more general comments (prefixed `AJ:`), that I'd be happy to try to fix but which I think warrant a discussion first. 

# OCaml-eglot

> AJ: is the name of the package 'OCaml-eglot' or `ocaml-eglot`?

...

> [!WARNING]
> `ocaml-eglot` is **experimental** and at an early stage
> of development. While we're very happy to collect user feedback.


> AJ: the above phrase seems cut off. Perhaps you want to replace
> "While" with "Meanwhile". Do you want to communicate something
> "we're beta, so be aware that some things may be broken. in the
> meantime, we're happy to collect feedback from early adopters"?

... Its aim is to offer a
user experience as close as possible to that offered by the Emacs mode
[Merlin](https://ocaml.github.io/merlin/editor/emacs/).

> AJ: and is the goal to replace merlin-mode? If so: "Its aim is to
> offer a user experience as close as possible to, and to replace, the
> Emacs mode ..."

### Make eglot less visually obtrusive

... One way of reducing this visual obtrusion is to disable type
annotations (`eldoc`) and `inlay-hints`:

> AJ: here, it'd be good to describe what the inlay-hints are. 

### Using `flycheck` instead of `flymake`

Out of the box, eglot uses `Flymake` as a syntax checker...

> AJ: 'as a syntax checker'? I don't think flymake is used for
> checking the syntax, but rather for visualizing and highlighting
> errors.

...

## Features

### Browsing errors

Eglot relies on
[Flymake](https://www.gnu.org/software/emacs/manual/html_node/emacs/Flymake.html)
for error diagnosis. 

> AJ: Again, is Flymake 'diagnosing' the errors? Rather visualizing,
> collecting them I guess? Also, btw, is there someway of seeing
> errors and jumping between errors not in the same file? Use `M-x
> flymake-show-project-diagnostics` to see all errors in the
> project. Btw, I see the same error twice (once prefixed `dune`, once
> `ocamllsp` both from the `e-f-b` backend), I wonder why. Then when I
> remove the error, I still see it but now from the backend `n`?? The
> functions below only move between the errors in the same project,
> right?

### Type Enclosings

> AJ: note that the face used highlight the area that is typed,
> `highlight`, is the same as is used by `hl-line-mode`
> (https://www.gnu.org/software/emacs/manual/html_node/emacs/Cursor-Display.html).
> Consequently, highlights are not visible, since the current line is
> already covered by that face. I don't really think that is an error
> in ocaml-eglot though.

In `ocaml-eglot` one can display the type of the expression below the cursor and
navigate the enclosing nodes while increasing or decreasing verbosity:

### Jump to definition/declaration

> AJ: I think that it's worth mentioning that: In addition to these,
> ocaml-eglot also provides an
> [xref](https://www.gnu.org/software/emacs/manual/html_node/emacs/Xref.html)
> backend. Such that, one can jump to the definition of an identifier
> using `M-.` (or `M-x xref-find-definitions`), and then go back using
> `M-,` (or `M-x xref-go-back`). It'd be good to have a discussion on
> whether there's any advantage to using ocaml-eglot's function
> compared to xref. For one, with eglot, you can choose whether you
> want implementation or signature, not sure xref has this.

`ocaml-eglot` provides a shortcut to quickly jump to the definition or
declaration of an identifier:

### Jump to type definition  of an expression

...

- `ocaml-eglot-find-type-definition-in-new-window`
- `ocaml-eglot-find-type-definition-in-current-window`

> AJ: these mentions seems misplaced.

- `ocaml-eglot-phrase-prev` (<kbd>C-c</kbd> <kbd>C-p</kbd>): jump to
  the beginning of the previous phrase
- `ocaml-eglot-phrase-next` (<kbd>C-c</kbd> <kbd>C-n</kbd>): jump to
  the beginning of the next phrase

### Get Documentation

> AJ: when you do `ocaml-eglot-document` on a identifier that lacks
> docs, there's no message or anything in the minibuffer. So it's hard
> to know if it works. Perhaps just display `(no docs)` or something.

![Get Documentation Example](media/document.gif)


### Search for values

> AJ: "does not support type parameters" I think an example of what is
> not supported would be useful here.

Search for values using a _by polarity_ query or a type expression. A
polarity query prefixes the function arguments with `-` and the return
with `+`. For example, to search for a function of this type: `int ->
string`. Search for `-int +string`. Searching by polarity does not
support type parameters...


---

Alternatively, you can search for a definition or declaration:
  
- `ocaml-eglot-search-definition` searches for a value definition by 
  its type or polarity
  
- `ocaml-eglot-search-declaration` searches for a value declaration by 
  its type or polarity

> AJ: a general comment, and I also think this applies to the jumping
> functions (`ocaml-eglot-find-{declaration,definition}`): Instead of
> having the user choose before hand whether they want declaration or
> definition, perhaps it's better to easily let them switch
> after-the-fact? That is, add a function
> `ocaml-eglot-alternate-decl-defn` that jumps between the declaration
> and the defn? Perhaps this can somehow tie in with
> `ocaml-eglot-alternate-file`?
