### PR TITLE
ocaml-eglot-alternate-file: find file alternate in other window

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ ocaml-eglot unreleased
 - Add `ocaml-eglot-search-definition`, `ocaml-eglot-search-declaration` and alternative functions ([#45](https://github.com/tarides/ocaml-eglot/pull/45))
 - Fix some warnings on byte-compilation ([#40](https://github.com/tarides/ocaml-eglot/pull/40))
 - Fix error on on `ocaml-eglot-construct` ([#42](https://github.com/tarides/ocaml-eglot/pull/40))
+- `ocaml-eglot-alternate-file` now visits file in other window when prefix argument is set ([#51](https://github.com/tarides/ocaml-eglot/pull/51))
 
 ocaml-eglot 1.1.0
 ======================

--- a/ocaml-eglot-util.el
+++ b/ocaml-eglot-util.el
@@ -194,7 +194,7 @@ If optional MARKERS, make markers instead."
 (defun ocaml-eglot-util--visit-file (strategy current-file new-file range)
   "Visits a referenced document, NEW-FILE at position  start of RANGE.
 The STRATEGY can be `'new' `'current' or `'smart'.  The later opens a
-new window if the destination is not in the CURRENT-FILE, ans uses the
+new window if the destination is not in the CURRENT-FILE, and uses the
 current window otherwise."
   (push-mark)
   (cond ((eq strategy 'new) (find-file-other-window new-file))

--- a/ocaml-eglot.el
+++ b/ocaml-eglot.el
@@ -296,16 +296,20 @@ If NEED-CONFIRMATION is set to non-nil, it will prompt a confirmation."
 
 ;; Find alternate file `ml<->mli'
 
-(defun ocaml-eglot-alternate-file ()
-  "Visit the alternative file (ml to mli and vice versa)."
-  (interactive)
-  ;; We don't relay on `tuareg-find-alternate-file‘ because the
+(defun ocaml-eglot-alternate-file (&optional in-other-window)
+  "Visit the alternative file (ml to mli and vice versa).
+
+If optional IN-OTHER-WINDOW is non-nil, find the file in another window."
+  (interactive "P")
+  ;; We don't rely on `tuareg-find-alternate-file‘ because the
   ;; interface generation relies on `ocamlmerlin’.
   (ocaml-eglot-req--server-capable-or-lose :experimental :ocamllsp :handleSwitchImplIntf)
   (when-let* ((current-uri (ocaml-eglot-util--current-uri))
               (uri (ocaml-eglot--find-alternate-file current-uri))
               (file (ocaml-eglot-util--uri-to-path uri)))
-    (find-file file)))
+    (if in-other-window
+        (find-file-other-window file)
+      (find-file file))))
 
 ;; Hook when visiting new interface file
 


### PR DESCRIPTION
Like the classic `ff-find-other-file` used by tuareg, open the alternate file in another window if the prefix argument is set. Also fix a spelling error.