### PR TITLE
Error fallback on jsonrpc request and retreive locate information

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,8 @@ ocaml-eglot unreleased
 - Fix some warnings on byte-compilation ([#40](https://github.com/tarides/ocaml-eglot/pull/40))
 - Fix error on on `ocaml-eglot-construct` ([#42](https://github.com/tarides/ocaml-eglot/pull/40))
 - `ocaml-eglot-alternate-file` now visits file in other window when prefix argument is set ([#51](https://github.com/tarides/ocaml-eglot/pull/51))
+- Add error-handling for jsonrpc-request ([#52](https://github.com/tarides/ocaml-eglot/pull/52))
+- Maintain more diagnostics for location failure ([#52](https://github.com/tarides/ocaml-eglot/pull/52))
 
 ocaml-eglot 1.1.0
 ======================

--- a/ocaml-eglot-util.el
+++ b/ocaml-eglot-util.el
@@ -42,7 +42,7 @@
 
 (defun ocaml-eglot-util--vec-first-or-nil (vec)
   "Return the first element of VEC or nil."
-  (when (not (equal vec []))
+  (when (and vec (not (equal vec [])))
     (aref vec 0)))
 
 (defun ocaml-eglot-util--uri-to-path (uri)


### PR DESCRIPTION
Allows errors to be used to produce more structured errors (particularly noticeable in jumps to definitions/declarations)