### PR TITLE
Try an autoload cookie to fix #60

### DIFF
--- a/ocaml-eglot.el
+++ b/ocaml-eglot.el
@@ -788,6 +788,7 @@ OCaml Eglot provides standard implementations of the various custom-requests
         create-lockfiles nil)
   (define-key ocaml-eglot-objinfo-mode-map (kbd "q") #'quit-window))
 
+;;;###autoload
 (defun ocaml-eglot--objinfo-handler ()
   "Display the result of `ocamlobjinfo` instead of file contents."
   (when (and buffer-file-name


### PR DESCRIPTION
This patch makes the desktop error messages go away, but I do not yet know whether it fixes #59.
On recent versions of Emacs  (I am using 30.1.50) it is possible to install the code of this repo with
```
(package-vc-install '(ocaml-eglot :url "https://github.com/gav451/ocaml-eglot.git"))
```