### PR TITLE
A reimplementation of `xref` backend that suit more with OCaml

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -2,7 +2,7 @@ unreleased
 ======================
 
 - Allows known compilation artifacts to be displayed via the `ocamlobjinfo` binary ([#56](https://github.com/tarides/ocaml-eglot/pull/56), [#61](https://github.com/tarides/ocaml-eglot/pull/61))
-- A total reimplementation of `xref` more suitable for OCaml ([#63](https://github.com/tarides/ocaml-eglot/pull/63))
+- A total reimplementation of `xref` more suitable for OCaml ([#64](https://github.com/tarides/ocaml-eglot/pull/64))
 
 ocaml-eglot 1.2.0
 ======================

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,7 +1,8 @@
 unreleased
 ======================
 
-- Allows known compilation artefacts to be displayed via the `ocamlobjinfo` binary ([#56](https://github.com/tarides/ocaml-eglot/pull/56), [#61](https://github.com/tarides/ocaml-eglot/pull/61))
+- Allows known compilation artifacts to be displayed via the `ocamlobjinfo` binary ([#56](https://github.com/tarides/ocaml-eglot/pull/56), [#61](https://github.com/tarides/ocaml-eglot/pull/61))
+- A total reimplementation of `xref` more suitable for OCaml ([#63](https://github.com/tarides/ocaml-eglot/pull/63))
 
 ocaml-eglot 1.2.0
 ======================

--- a/ocaml-eglot-req.el
+++ b/ocaml-eglot-req.el
@@ -21,6 +21,8 @@
 (require 'ocaml-eglot-util)
 (require 'jsonrpc)
 
+(defvar ocaml-eglot-locate-preference)
+
 ;;; Low-level plumbing to execute a request
 
 (defun ocaml-eglot-req--current-server ()
@@ -28,12 +30,12 @@
   (eglot--current-server-or-lose))
 
 (cl-defun ocaml-eglot-req--send (method params &key
-                                          immediate
-                                          timeout
-                                          cancel-on-input
-                                          cancel-on-input-retval
-                                          fallback
-                                          server)
+                                        immediate
+                                        timeout
+                                        cancel-on-input
+                                        cancel-on-input-retval
+                                        fallback
+                                        server)
   "Execute a custom request on the current LSP server.
 METHOD is the dedicated lsp server request, PARAMS is the parameters of the
 query, IMMEDIATE is a flag to trigger the request only if the document has
@@ -269,7 +271,7 @@ or the implementation."
 
 (defun ocaml-eglot-req--locate-for-xref (symbol)
   "Locate an idenfier based on SYMBOL used for xref."
-  (let ((argv (if-let ((pt (get-text-property 0 'ocaml-eglot-xref-point symbol)))
+  (let ((argv (if-let* ((pt (get-text-property 0 'ocaml-eglot-xref-point symbol)))
                   ;; SYMBOL is from `xref-backend-identifier-at-point',
                   ;; since if it was read from the minibuffer its text
                   ;; properties would have been stripped

--- a/ocaml-eglot-req.el
+++ b/ocaml-eglot-req.el
@@ -21,8 +21,6 @@
 (require 'ocaml-eglot-util)
 (require 'jsonrpc)
 
-(defvar ocaml-eglot-locate-preference)
-
 ;;; Low-level plumbing to execute a request
 
 (defun ocaml-eglot-req--current-server ()
@@ -261,36 +259,6 @@ or the implementation."
                       "-look-for" (pcase look-for
                                     ('interface "interface")
                                     (_ "implementation")))))
-    (ocaml-eglot-req--merlin-call "locate" argv)))
-
-(defun ocaml-eglot-req--occurences (pt)
-  "Call merlin-occurences for given PT."
-  (let ((argv (vector "-scope" "project"
-                      "-identifier-at" (ocaml-eglot-util-point-as-arg pt))))
-    (ocaml-eglot-req--merlin-call "occurrences" argv)))
-
-(defun ocaml-eglot-req--locate-for-xref (symbol)
-  "Locate an idenfier based on SYMBOL used for xref."
-  (let ((argv (if-let* ((pt (get-text-property 0 'ocaml-eglot-xref-point symbol)))
-                  ;; SYMBOL is from `xref-backend-identifier-at-point',
-                  ;; since if it was read from the minibuffer its text
-                  ;; properties would have been stripped
-                  ;; (see `minibuffer-allow-text-properties').  Just pass
-                  ;; position and Merlin will figure out everything from that.
-                  (vector "-position" (ocaml-eglot-util-point-as-arg pt)
-                          "-look-for" ocaml-eglot-locate-preference)
-                ;; SYMBOL was probably just typed in by the user.  So pass it
-                ;; to Merlin, removing a trailing "." in case the user completed
-                ;; a module name with `merlin-cap-dot-after-module':
-                (vector "-prefix" (string-remove-suffix "." symbol)
-                        ;; We don't know if SYMBOL is a module or type or
-                        ;; expr, and we shouldn't use -position to guess.
-                        ;; See: https://github.com/janestreet/merlin-jst/pull/91
-                        "-context" "unknown"
-                        "-position" (ocaml-eglot-util-point-as-arg (point))
-                        ;; And use `point' to pick the lexical environment to
-                        ;; search:
-                        "-look-for" ocaml-eglot-locate-preference))))
     (ocaml-eglot-req--merlin-call "locate" argv)))
 
 (provide 'ocaml-eglot-req)

--- a/ocaml-eglot-util.el
+++ b/ocaml-eglot-util.el
@@ -20,9 +20,6 @@
 (require 'eglot)
 (require 'cl-lib)
 
-(defclass ocaml-eglot-server (eglot-lsp-server) ()
-  :documentation "OCaml-eglot Language Server.")
-
 ;; Generic util
 
 (defun ocaml-eglot-util--goto-char (target)

--- a/ocaml-eglot-util.el
+++ b/ocaml-eglot-util.el
@@ -23,19 +23,6 @@
 (defclass ocaml-eglot-server (eglot-lsp-server) ()
   :documentation "OCaml-eglot Language Server.")
 
-(defun ocaml-eglot-util--make-server (orig-fn &rest args)
-  "Wrap `make-instance` to return `ocaml-eglot-server` using ORIG-FN and ARGS."
-  (let ((class (car args)))
-    (if (and (eq class 'eglot-lsp-server)
-             (member major-mode '(tuareg-mode
-                                  caml-mode
-                                  neocaml-mode
-                                  neocamli-mode)))
-        (apply orig-fn 'ocaml-eglot-server (cdr args))
-      (apply orig-fn args))))
-
-(advice-add 'make-instance :around #'ocaml-eglot-util--make-server)
-
 ;; Generic util
 
 (defun ocaml-eglot-util--goto-char (target)

--- a/ocaml-eglot-util.el
+++ b/ocaml-eglot-util.el
@@ -111,7 +111,7 @@ If optional MARKERS, make markers instead."
         (byte-to-position target)))))
 
 (defun ocaml-eglot-util--pos-to-point (pos)
-  "Converts a POS to a point."
+  "Convert a POS to a point."
   (let ((line (cl-getf pos :line))
         (col (cl-getf pos :col)))
     (ocaml-eglot-util--point-by-pos line col)))

--- a/ocaml-eglot-xref.el
+++ b/ocaml-eglot-xref.el
@@ -1,13 +1,11 @@
 ;;; ocaml-eglot-xref.el --- Xref backend for OCaml   -*- coding: utf-8; lexical-binding: t -*-
 
-;; TODO: Fix Copyright accredit.
-;; Copyright (C) 2025  Xavier Van de Woestyne
+;; Copyright (C) 2025  The OCaml-eglot Project Contributors
 ;; Licensed under the MIT license.
 
-;; TODO: Fix Authors accredit.
 ;; Author: Xavier Van de Woestyne <xaviervdw@gmail.com>
+;;         Spencer Baugh
 ;; Created: 10 June 2025
-;; TODO: Clarify license
 ;; SPDX-License-Identifier: MIT
 
 ;;; Commentary:

--- a/ocaml-eglot-xref.el
+++ b/ocaml-eglot-xref.el
@@ -109,7 +109,7 @@ Requires that the current buffer be the buffer of FILE."
            (- end-pos start-pos))))
     ;; We don't have the file open, so we can't make a real summary or decode
     ;; the length.  We'll just use the symbol as the summary instead.
-    (xref-make symbol location)))
+    (xref-make symbol xref-loc)))
 
 (cl-defmethod xref-backend-references ((_backend (eql ocaml-eglot-xref)) symbol)
   "An `xref-backend-references' for SYMBOL for OCaml-eglot."
@@ -125,6 +125,7 @@ Requires that the current buffer be the buffer of FILE."
     (reverse result)))
 
 (cl-defmethod xref-backend-definitions ((_backend (eql ocaml-eglot-xref)) symbol)
+  "Extension of `xref-backend-definitions' for SYMBOL."
   (let* ((result (ocaml-eglot-req--locate-for-xref symbol))
          (loc (ocaml-eglot-util--merlin-call-result result)))
     ;; Error handling should be already guarded.
@@ -174,6 +175,7 @@ Requires that the current buffer be the buffer of FILE."
   (rx symbol-start (in "A-Za-z_") (* (in "A-Za-z0-9_'"))))
 
 (cl-defmethod xref-backend-identifier-at-point ((_backend (eql ocaml-eglot-xref)))
+  "Extension of `xref-backend-identifier-at-point'."
   (let ((symbol
          (cond
           ;; binding operator starting at point

--- a/ocaml-eglot-xref.el
+++ b/ocaml-eglot-xref.el
@@ -164,7 +164,9 @@ Requires that the current buffer be the buffer of FILE."
   "Extension of `xref-backend-definitions' for SYMBOL."
   (let* ((result (ocaml-eglot-xref--call-locate symbol))
          (loc (ocaml-eglot-util--merlin-call-result result)))
-    ;; Error handling should be already guarded.
+    (unless loc (error "Not found.  (Check *Messages* for potential errors)"))
+    ;; In this case, an error is returned.
+    (if (stringp loc) (user-error "%s" loc))
     (list
      (xref-make
       symbol

--- a/ocaml-eglot.el
+++ b/ocaml-eglot.el
@@ -751,6 +751,14 @@ and print its type."
       ("ocaml.next-hole" (ocaml-eglot--command-next-hole arguments))
       (_ (cl-call-next-method)))))
 
+;;; Handle XRef backend
+
+(defun ocaml-eglot--enable-xref-backend ()
+  "Register the OCaml-eglot-xref-backend if it is relevant."
+  (when (and eglot--managed-mode
+             (object-of-class-p (ocaml-eglot-req--current-server) 'ocaml-eglot-server))
+    (add-hook 'xref-backend-functions #'ocaml-eglot-xref-backend nil t)))
+
 ;;; Mode
 
 (defvar ocaml-eglot-map
@@ -777,7 +785,10 @@ OCaml Eglot provides standard implementations of the various custom-requests
   :lighter " OCaml-eglot"
   :keymap ocaml-eglot-map
   :group 'ocaml-eglot
-  (add-hook 'find-file-hook #'ocaml-eglot--file-hook))
+  (add-hook 'find-file-hook #'ocaml-eglot--file-hook)
+  (if ocaml-eglot
+      (add-hook 'eglot-managed-mode-hook #'ocaml-eglot--enable-xref-backend nil t)
+    (remove-hook 'eglot-managed-mode-hook #'ocaml-eglot--enable-xref-backend t)))
 
 ;;; Ocamlobjinfo mode
 
@@ -812,17 +823,6 @@ OCaml Eglot provides standard implementations of the various custom-requests
 
 ;;;###autoload
 (add-hook 'find-file-hook #'ocaml-eglot-objinfo-handler)
-
-;;; Handle XRef backend
-
-(defun ocaml-eglot--enable-xref-backend ()
-  "Register the OCaml-eglot-xref-backend if it is relevant."
-  (when (and eglot--managed-mode
-             (object-of-class-p (ocaml-eglot-req--current-server) 'ocaml-eglot-server))
-    (add-hook 'xref-backend-functions #'ocaml-eglot-xref-backend nil t)))
-
-;;;###autoload
-(add-hook 'eglot-managed-mode-hook #'ocaml-eglot--enable-xref-backend)
 
 (provide 'ocaml-eglot)
 ;;; ocaml-eglot.el ends here

--- a/ocaml-eglot.el
+++ b/ocaml-eglot.el
@@ -439,9 +439,7 @@ If there is no available holes, it returns the first one of HOLES."
          (json-result (ocaml-eglot-util--merlin-call-result result))
          (pos (cl-getf json-result :pos)))
     (when pos
-      (let* ((line (cl-getf pos :line))
-             (col (cl-getf pos :col))
-             (target (ocaml-eglot-util--point-by-pos line col)))
+      (let ((target (ocaml-eglot-util--pos-to-point pos)))
         (ocaml-eglot-util--goto-char target)))))
 
 (defun ocaml-eglot-phrase-next ()

--- a/ocaml-eglot.el
+++ b/ocaml-eglot.el
@@ -717,7 +717,7 @@ and print its type."
 ;; capabilities supported by the client (the editor) and provision
 ;; them to the server as supported capabilities.
 
-(cl-defmethod eglot-client-capabilities :around ((server ocaml-eglot-server))
+(cl-defmethod eglot-client-capabilities :around ((_server ocaml-eglot-server))
   "Add client capabilities to Eglot for OCaml LSP server."
   (let* ((capabilities (copy-tree (cl-call-next-method)))
          (experimental-capabilities (cl-getf capabilities :experimental))
@@ -733,7 +733,7 @@ and print its type."
 ;; it, otherwise we leave it to the previous implementation.
 
 (when (fboundp 'eglot-execute)
-  (cl-defmethod eglot-execute :around ((server ocaml-eglot-server) action)
+  (cl-defmethod eglot-execute :around ((_server ocaml-eglot-server) action)
     "Custom handler for performing client commands."
     (pcase (cl-getf action :command)
       ("ocaml.next-hole" (ocaml-eglot--command-next-hole
@@ -745,7 +745,7 @@ and print its type."
 ;; `eglot-execute-command' (< 30).
 
 (when (fboundp 'eglot-execute-command)
-  (cl-defmethod eglot-execute-command :around ((server ocaml-eglot-server) command arguments)
+  (cl-defmethod eglot-execute-command :around ((_server ocaml-eglot-server) command arguments)
     "Custom handler for performing client commands (legacy)."
     (pcase command
       ("ocaml.next-hole" (ocaml-eglot--command-next-hole arguments))
@@ -817,10 +817,8 @@ OCaml Eglot provides standard implementations of the various custom-requests
 
 (defun ocaml-eglot--enable-xref-backend ()
   "Register the OCaml-eglot-xref-backend if it is relevant."
-  (print (and eglot--managed-mode
-             (cl-typep (ocaml-eglot-req--current-server) 'ocaml-eglot-server)))
   (when (and eglot--managed-mode
-             (cl-typep (ocaml-eglot-req--current-server) 'ocaml-eglot-server))
+             (object-of-class-p (ocaml-eglot-req--current-server) 'ocaml-eglot-server))
     (add-hook 'xref-backend-functions #'ocaml-eglot-xref-backend nil t)))
 
 ;;;###autoload

--- a/ocaml-eglot.el
+++ b/ocaml-eglot.el
@@ -99,12 +99,6 @@ Otherwise, `merlin-construct' only includes constructors."
           (const "-decls")
           (const "-uid-deps")))
 
-(defcustom ocaml-eglot-locate-preference 'ml
-  "Determine whether locate should in priority look in ml or mli files."
-  :group 'ocaml-eglot
-  :type '(choice (const :tag "Look at implementation" ml)
-                 (const :tag "Look at interfaces" mli)))
-
 ;;; Faces
 
 (defface ocaml-eglot-value-name-face


### PR DESCRIPTION
cc @catern 
Can you review the following patch? There is some need for attribution (in the header) and `merlin-cap-for` seems missing making `xref-backend-identifier-completion-table` complicated to be implemented.

Thanks in advance. The code should not diverge to much from your implementation.