### PR TITLE
Add command [ocaml-eglot-type-annotate]

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@ unreleased
 - A total reimplementation of `xref` more suitable for OCaml ([#64](https://github.com/tarides/ocaml-eglot/pull/64))
 - Remove `C-c C-c` for `ocaml-eglot-error-prev`, clash with usual `compile` ([#67](https://github.com/tarides/ocaml-eglot/pull/67))
 - Rewrite `find/locate` function in term of `xref` ([#73](https://github.com/tarides/ocaml-eglot/pull/73))
+- Add `ocaml-eglot-type-annotate` for type annotating type enclosed expressions ([#74](https://github.com/tarides/ocaml-eglot/pull/74))
 
 ocaml-eglot 1.2.0
 ======================

--- a/ocaml-eglot-type-enclosing.el
+++ b/ocaml-eglot-type-enclosing.el
@@ -49,6 +49,7 @@
     (define-key keymap (kbd "C-c C-t") #'ocaml-eglot-type-enclosing-increase-verbosity)
     (define-key keymap (kbd "C-<right>") #'ocaml-eglot-type-enclosing-increase-verbosity)
     (define-key keymap (kbd "C-<left>") #'ocaml-eglot-type-enclosing-decrease-verbosity)
+    (define-key keymap (kbd "C-'") #'ocaml-eglot-type-annotate)
     keymap)
   "Keymap for OCaml-eglot's type enclosing transient mode.")
 
@@ -109,6 +110,21 @@ If PREV-VERB is given, the verbosity change ensure that the type is different."
           (mod (1- ocaml-eglot-type-enclosing-offset)
                (length ocaml-eglot-type-enclosing-types)))
     (ocaml-eglot-type-enclosing--with-fixed-offset)))
+
+(defun ocaml-eglot-type-annotate ()
+  "Type annotate the expression of the current enclosing with its type."
+  (interactive)
+  (when-let*
+      ((type ocaml-eglot-type-enclosing-current-type)
+       (enclosing (aref ocaml-eglot-type-enclosing-types ocaml-eglot-type-enclosing-offset))
+       (beg (eglot--lsp-position-to-point (cl-getf enclosing :start)))
+       (end (eglot--lsp-position-to-point (cl-getf enclosing :end))))
+    (progn
+      (save-excursion
+        (goto-char beg)
+        (insert ?\())
+      (goto-char (+ 1 end))
+      (insert " : " type ")"))))
 
 (defun ocaml-eglot-type-enclosing--type-buffer (type-expr)
   "Create buffer with content TYPE-EXPR of the enclosing type buffer."


### PR DESCRIPTION
Add a new command `ocaml-eglot-type-annotate` to `ocaml-eglot-type-enclosing-map` that inserts a type annotation for the current enclosing with its inferred type:


https://github.com/user-attachments/assets/3ae80465-e39c-4a5f-96d3-cbde785cf04c

TBH, not yet sure how useful it is. 
