### PR TITLE
Fix "xref-pop-to-location: Marker does not point anywhere"

### DIFF
--- a/ocaml-eglot-util.el
+++ b/ocaml-eglot-util.el
@@ -92,7 +92,12 @@ If optional MARKERS, make markers instead."
       (let* ((offset-l (position-bytes (point)))
              (offset-c (max 0 col))
              (target (+ offset-l offset-c)))
-        (byte-to-position target)))))
+        (or (byte-to-position target)
+            ;; The target can be out of bounds in generated files with
+            ;; line number directives, and it's difficult to get this
+            ;; behavior exactly right in Emacs.  Do our best to
+            ;; avoid returning nil.
+            (point-max))))))
 
 (defun ocaml-eglot-util--pos-to-point (pos)
   "Convert a POS to a point."


### PR DESCRIPTION
Avoid a possible error when jumping to a position in a file that is
out of bounds, due to the jumped-to file containing line number
directives.  E.g., if target.ml's first line is "# 100 \"target.ml\"",
the right place to jump for line 100 would be the second physical line
of the file, but getting this right would be quite complex.  As a
first step, just produce *some* valid position in the right buffer so
that xref-find-definitions does not fail completely.

The ultimate error manifests as:

    xref-pop-to-location: Marker does not point anywhere

(and the xref-find-definitions command jumps to some random buffer):
due to the xref-location-marker method returning a marker that does
not point anywhere.