### PR TITLE
Dead code removal and minor fixes

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,12 @@
+Unreleased
+======================
+
+- Remove dead code left over from the xref backend rewrite ([#90](https://github.com/tarides/ocaml-eglot/pull/90))
+- Fix `compare-position` nil handling (was always returning 0) ([#90](https://github.com/tarides/ocaml-eglot/pull/90))
+- Use `find-file-noselect` in `load-uri` to avoid buffer flicker ([#90](https://github.com/tarides/ocaml-eglot/pull/90))
+- Simplify `on-interface` to avoid redundant extension check ([#90](https://github.com/tarides/ocaml-eglot/pull/90))
+- Avoid re-initializing major mode on every type display update ([#90](https://github.com/tarides/ocaml-eglot/pull/90))
+
 ocaml-eglot 1.3.0
 ======================
 Wed Feb 25 04:21:45 PM CET 2026

--- a/ocaml-eglot-req.el
+++ b/ocaml-eglot-req.el
@@ -71,10 +71,6 @@ request fails.  SERVER can also be conditionally given."
   "Compute `TextDocumentIdentifier' object for current buffer."
   (eglot--TextDocumentIdentifier))
 
-(defun ocaml-eglot-req--PlainUri ()
-  "A hack for requests that do not respect the URI parameter scheme."
-  (make-vector 1 (ocaml-eglot-util--current-uri)))
-
 (defun ocaml-eglot-req--TextDocumentPositionParams ()
   "Compute `TextDocumentPositionParams' object for the current buffer."
   (append
@@ -190,22 +186,10 @@ under the cursor.  The MARKUP-KIND can also be configured."
   (let ((error-data (alist-get 'jsonrpc-error-data err)))
     (eglot--error "%s" error-data)))
 
-(defun ocaml-eglot-req--definition ()
-  "Execute the `textDocument/definition' request for the current point."
-  (let ((params (ocaml-eglot-req--TextDocumentPositionParams)))
-    (ocaml-eglot-req--send :textDocument/definition params
-                           :fallback 'ocaml-eglot-req--locate-fallback)))
-
 (defun ocaml-eglot-req--type-definition ()
   "Execute the `textDocument/typeDefinition' request for the current point."
   (let ((params (ocaml-eglot-req--TextDocumentPositionParams)))
     (ocaml-eglot-req--send :textDocument/typeDefinition params
-                           :fallback 'ocaml-eglot-req--locate-fallback)))
-
-(defun ocaml-eglot-req--declaration ()
-  "Execute the `textDocument/declaration' request for the current point."
-  (let ((params (ocaml-eglot-req--TextDocumentPositionParams)))
-    (ocaml-eglot-req--send :textDocument/declaration params
                            :fallback 'ocaml-eglot-req--locate-fallback)))
 
 (defun ocaml-eglot-req--type-enclosings (at index verbosity)

--- a/ocaml-eglot-type-enclosing.el
+++ b/ocaml-eglot-type-enclosing.el
@@ -113,13 +113,14 @@ If PREV-VERB is given, the verbosity change ensure that the type is different."
 
 (defun ocaml-eglot-type-enclosing--type-buffer (type-expr)
   "Create buffer with content TYPE-EXPR of the enclosing type buffer."
-  ; We store the current major mode to be used in the type buffer for
-  ; syntax highlighting.
+  ;; We use the current major mode in the type buffer for syntax
+  ;; highlighting, but only switch if it has changed.
   (let ((curr-dir default-directory)
         (current-major-mode major-mode))
     (with-current-buffer (get-buffer-create ocaml-eglot-type-buffer-name)
       (read-only-mode 0)
-      (funcall current-major-mode)
+      (unless (eq major-mode current-major-mode)
+        (funcall current-major-mode))
       (erase-buffer)
       (insert type-expr)
       (goto-char (point-min))

--- a/ocaml-eglot-util.el
+++ b/ocaml-eglot-util.el
@@ -66,12 +66,8 @@ If optional MARKERS, make markers instead."
   "Check and load if URI is available for typechecking."
   (let ((path (ocaml-eglot-util--uri-to-path uri)))
     (when (file-exists-p path)
-      (if (member path (mapcar #'buffer-file-name (buffer-list)))
-          t
-        (let ((buf (current-buffer)))
-          (find-file path)
-          (switch-to-buffer buf)
-          t)))))
+      (find-file-noselect path)
+      t)))
 
 (defun ocaml-eglot-util-point-as-arg (point)
   "Compute POINT as a valid Merlin position."

--- a/ocaml-eglot-util.el
+++ b/ocaml-eglot-util.el
@@ -160,11 +160,9 @@ A nil position is considered less than a non-nil one."
     (string-match-p "\\.\\(mli\\|rei\\|eliomi\\)\\'" file)))
 
 (defun ocaml-eglot-util--on-interface ()
-  "Return non-nil if the current URI is an interface, nil otherwise."
-  (when (and buffer-file-name
-             (string-match-p "\\.\\(mli\\|rei\\|eliomi\\)\\'" buffer-file-name))
-    (let ((uri (ocaml-eglot-util--current-uri)))
-      (ocaml-eglot-util--is-interface uri))))
+  "Return non-nil if the current buffer is an interface, nil otherwise."
+  (and buffer-file-name
+       (string-match-p "\\.\\(mli\\|rei\\|eliomi\\)\\'" buffer-file-name)))
 
 (defun ocaml-eglot-util--ensure-interface ()
   "Ensure that a function is called on a interface file."

--- a/ocaml-eglot-util.el
+++ b/ocaml-eglot-util.el
@@ -149,14 +149,6 @@ If optional MARKERS, make markers instead."
          (new-char (+ character (length content))))
     `(:line ,line :character ,new-char)))
 
-(defun ocaml-eglot-util--merlin-location-to-lsp (location)
-  "Convert a Merlin's LOCATION to an LSP one."
-  (let* ((uri (cl-getf location :file))
-         (pos (cl-getf location :pos))
-         (lsp-pos (ocaml-eglot-util--merlin-pos-to-lsp-pos pos))
-         (range (list :start lsp-pos :end lsp-pos)))
-    (list :uri uri :range range)))
-
 (defun ocaml-eglot-util--current-uri ()
   "Return the uri of the document currently being visited."
   (cl-getf (eglot--TextDocumentIdentifier) :uri))
@@ -172,11 +164,6 @@ If optional MARKERS, make markers instead."
              (string-match-p "\\.\\(mli\\|rei\\|eliomi\\)\\'" buffer-file-name))
     (let ((uri (ocaml-eglot-util--current-uri)))
       (ocaml-eglot-util--is-interface uri))))
-
-(defun ocaml-eglot-util--ensure-is-interface (uri)
-  "Ensure that a function is called given an interface file (URI)."
-  (when (not (ocaml-eglot-util--is-interface uri))
-    (eglot--error "Function is only available for interfaces")))
 
 (defun ocaml-eglot-util--ensure-interface ()
   "Ensure that a function is called on a interface file."

--- a/ocaml-eglot-util.el
+++ b/ocaml-eglot-util.el
@@ -124,17 +124,22 @@ If optional MARKERS, make markers instead."
     (ocaml-eglot-util--goto-char (eglot--lsp-position-to-point start))))
 
 (defun ocaml-eglot-util--compare-position (a b)
-  "Comparison between two LSP positions, A and B."
-  (if (and a b)
-      (let ((char-a (cl-getf a :character))
-            (char-b (cl-getf b :character))
-            (line-a (cl-getf a :line))
-            (line-b (cl-getf b :line)))
-        (if (> line-a line-b) 1
-          (if (> line-b line-a) -1
-            (if (> char-a char-b) 1
-              (if (> char-b char-a) -1 0)))))
-    (when a 1) (when b -1) 0))
+  "Comparison between two LSP positions, A and B.
+Return 1 if A > B, -1 if A < B, 0 if equal.
+A nil position is considered less than a non-nil one."
+  (cond
+   ((and a b)
+    (let ((char-a (cl-getf a :character))
+          (char-b (cl-getf b :character))
+          (line-a (cl-getf a :line))
+          (line-b (cl-getf b :line)))
+      (if (> line-a line-b) 1
+        (if (> line-b line-a) -1
+          (if (> char-a char-b) 1
+            (if (> char-b char-a) -1 0))))))
+   (a 1)
+   (b -1)
+   (t 0)))
 
 (defun ocaml-eglot-util--merlin-pos-to-lsp-pos (pos)
   "Compute a LSP position from a Merlin's POS (as LINE/COL)."

--- a/ocaml-eglot.el
+++ b/ocaml-eglot.el
@@ -456,8 +456,8 @@ KEY-COMPLETABLE define the current value to be selected."
 The universal prefix argument can be used to change the maximum number
 of results (LIMIT).  KEY defines the current value to be selected."
   (ocaml-eglot-req--server-capable-or-lose :experimental :ocamllsp :handleTypeSearch)
-  (let* ((limit (or(if (> limit 1) limit nil)
-                   ocaml-eglot-type-search-limit 25))
+  (let* ((limit (or (if (> limit 1) limit nil)
+                    ocaml-eglot-type-search-limit))
          (with-doc (or ocaml-eglot-type-search-include-doc :json-false))
          ;; We use plaintext because the result of the documentation may
          ;; be truncated

--- a/ocaml-eglot.el
+++ b/ocaml-eglot.el
@@ -253,7 +253,7 @@ If optional IN-OTHER-WINDOW is non-nil, find the file in another window."
 If optional IN-OTHER-WINDOW is non-nil, find the declaration in another window."
   (interactive "P")
   (let* ((identifier (xref-backend-identifier-at-point (xref-find-backend)))
-         (identifier-str (progn (substring-no-properties identifier)))
+         (identifier-str (substring-no-properties identifier))
          (alternate-buffer
           (progn
             (ocaml-eglot-req--server-capable-or-lose :experimental :ocamllsp :handleSwitchImplIntf)


### PR DESCRIPTION
I noticed a few unused functions while going through the codebase -- I'm not sure what their original purpose was, but they seem to have become obsolete at some point (likely after the xref backend rewrite), so I cleaned them up. The removed functions are:

- `ocaml-eglot-req--PlainUri`
- `ocaml-eglot-req--definition` and `--declaration`
- `ocaml-eglot-util--ensure-is-interface`
- `ocaml-eglot-util--merlin-location-to-lsp`
- unreachable `25` fallback in the search limit `or` chain

On top of that there are a few small fixes:

- `compare-position` had a bug in the nil handling branch (the `when` return values were silently discarded in an implicit progn, so the function always returned 0 when either position was nil)
- `load-uri` used `find-file` + `switch-to-buffer` instead of `find-file-noselect`, causing visible buffer flicker and spurious hook triggers
- `on-interface` checked the file extension twice (once on `buffer-file-name`, then again via URI conversion)
- unnecessary `progn` in `find-identifier-in-alternate-file`
- the type display buffer re-initialized the major mode on every update (grow/shrink/verbosity), now it only switches when the mode has actually changed