### PR TITLE
Rename minor mode to ocaml-eglot-mode

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Unreleased
 - Simplify `on-interface` to avoid redundant extension check ([#90](https://github.com/tarides/ocaml-eglot/pull/90))
 - Avoid re-initializing major mode on every type display update ([#90](https://github.com/tarides/ocaml-eglot/pull/90))
 - Remove `ocaml-eglot-objinfo` in favor to `neocaml-objinfo` ([#92](https://github.com/tarides/ocaml-eglot/pull/92))
+- Rename minor mode from `ocaml-eglot` to `ocaml-eglot-mode` (old name kept as alias)
 
 ocaml-eglot 1.3.0
 ======================

--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ Here's an example with Tuareg already installed:
   :ensure t
   :after tuareg
   :hook
-  (tuareg-mode . ocaml-eglot)
-  (ocaml-eglot . eglot-ensure))
+  (tuareg-mode . ocaml-eglot-mode)
+  (ocaml-eglot-mode . eglot-ensure))
 ```
 
 ### Foreword on configuration
@@ -107,10 +107,10 @@ Eglot provides a hook to format the buffer on saving:
    :ensure t
    :after tuareg
    :hook
-   (tuareg-mode . ocaml-eglot)
--  (ocaml-eglot . eglot-ensure))
-+  (ocaml-eglot . eglot-ensure)
-+  (ocaml-eglot . (lambda ()
+   (tuareg-mode . ocaml-eglot-mode)
+-  (ocaml-eglot-mode . eglot-ensure))
++  (ocaml-eglot-mode . eglot-ensure)
++  (ocaml-eglot-mode . (lambda ()
 +                   (add-hook #'before-save-hook #'eglot-format nil t))))
 ```
 
@@ -126,9 +126,9 @@ and `inlay-hints`:
    :ensure t
    :after tuareg
    :hook
-   (tuareg-mode . ocaml-eglot)
--  (ocaml-eglot . eglot-ensure))
-+  (ocaml-eglot . eglot-ensure)
+   (tuareg-mode . ocaml-eglot-mode)
+-  (ocaml-eglot-mode . eglot-ensure))
++  (ocaml-eglot-mode . eglot-ensure)
 +  (eglot-managed-mode . (lambda ()
 +                          (eldoc-mode -1)
 +                          (eglot-inlay-hints-mode -1))))
@@ -174,9 +174,9 @@ configuration in this way:
    :ensure t
    :after tuareg
    :hook
-   (tuareg-mode . ocaml-eglot)
--  (ocaml-eglot . eglot-ensure))
-+  (ocaml-eglot . eglot-ensure)
+   (tuareg-mode . ocaml-eglot-mode)
+-  (ocaml-eglot-mode . eglot-ensure))
++  (ocaml-eglot-mode . eglot-ensure)
 +  (eglot-managed-mode . (lambda () (flycheck-eglot-mode 1)))
 +  :config
 +  (setq ocaml-eglot-syntax-checker 'flycheck))
@@ -198,9 +198,9 @@ configured in this way:
    :ensure t
    :after tuareg
    :hook
-   (tuareg-mode . ocaml-eglot)
--  (ocaml-eglot . eglot-ensure))
-+  (ocaml-eglot . eglot-ensure)
+   (tuareg-mode . ocaml-eglot-mode)
+-  (ocaml-eglot-mode . eglot-ensure))
++  (ocaml-eglot-mode . eglot-ensure)
 +  :config
 +  (with-eval-after-load 'eglot
 +    (add-to-list 'eglot-server-programs
@@ -247,9 +247,9 @@ Here is a recommended minimal configuration to take full advantage of
   :ensure t
   :after tuareg
   :hook
-  (tuareg-mode . ocaml-eglot)
-  (ocaml-eglot . eglot-ensure)
-  (ocaml-eglot . (lambda () (add-hook #'before-save-hook #'eglot-format nil t)))
+  (tuareg-mode . ocaml-eglot-mode)
+  (ocaml-eglot-mode . eglot-ensure)
+  (ocaml-eglot-mode . (lambda () (add-hook #'before-save-hook #'eglot-format nil t)))
   :config
   (setq ocaml-eglot-syntax-checker 'flymake))
 
@@ -265,7 +265,7 @@ Here is a recommended minimal configuration to take full advantage of
 (use-package ocp-indent
   :ensure t
   :config
-  (add-hook 'ocaml-eglot-hook 'ocp-setup-indent))
+  (add-hook 'ocaml-eglot-mode-hook 'ocp-setup-indent))
 ```
 
 Using this configuration should provide a pleasant OCaml development

--- a/ocaml-eglot.el
+++ b/ocaml-eglot.el
@@ -687,42 +687,50 @@ and print its type."
 
 ;;; Mode
 
-(defvar ocaml-eglot-map
-  (let ((ocaml-eglot-keymap (make-sparse-keymap)))
-    (define-key ocaml-eglot-keymap (kbd "C-c C-x") #'ocaml-eglot-error-next)
-    (define-key ocaml-eglot-keymap (kbd "C-c C-l") #'ocaml-eglot-find-definition)
-    (define-key ocaml-eglot-keymap (kbd "C-c C-i") #'ocaml-eglot-find-declaration)
-    (define-key ocaml-eglot-keymap (kbd "C-c C-a") #'ocaml-eglot-alternate-file)
-    (define-key ocaml-eglot-keymap (kbd "C-c C-d") #'ocaml-eglot-document)
-    (define-key ocaml-eglot-keymap (kbd "C-c C-t") #'ocaml-eglot-type-enclosing)
-    (define-key ocaml-eglot-keymap (kbd "C-c |") #'ocaml-eglot-destruct)
-    (define-key ocaml-eglot-keymap (kbd "C-c \\") #'ocaml-eglot-construct)
-    (define-key ocaml-eglot-keymap (kbd "C-c C-p") #'ocaml-eglot-phrase-prev)
-    (define-key ocaml-eglot-keymap (kbd "C-c C-n") #'ocaml-eglot-phrase-next)
-    ocaml-eglot-keymap)
-  "Keymap for OCaml-eglot minor mode.")
+(defvar ocaml-eglot-mode-map
+  (let ((map (make-sparse-keymap)))
+    (define-key map (kbd "C-c C-x") #'ocaml-eglot-error-next)
+    (define-key map (kbd "C-c C-l") #'ocaml-eglot-find-definition)
+    (define-key map (kbd "C-c C-i") #'ocaml-eglot-find-declaration)
+    (define-key map (kbd "C-c C-a") #'ocaml-eglot-alternate-file)
+    (define-key map (kbd "C-c C-d") #'ocaml-eglot-document)
+    (define-key map (kbd "C-c C-t") #'ocaml-eglot-type-enclosing)
+    (define-key map (kbd "C-c |") #'ocaml-eglot-destruct)
+    (define-key map (kbd "C-c \\") #'ocaml-eglot-construct)
+    (define-key map (kbd "C-c C-p") #'ocaml-eglot-phrase-prev)
+    (define-key map (kbd "C-c C-n") #'ocaml-eglot-phrase-next)
+    map)
+  "Keymap for `ocaml-eglot-mode'.")
 
-;;;###autoload
-(defun ocaml-eglot-setup ()
+(defun ocaml-eglot--setup ()
   "Setup OCaml-eglot."
   (add-hook 'find-file-hook #'ocaml-eglot--file-hook)
   (add-hook 'eglot-managed-mode-hook #'ocaml-eglot--enable-xref-backend nil t))
 
-;;;###autoload
-(defun ocaml-eglot-clean ()
+(defun ocaml-eglot--clean ()
   "Clean registered hooks and advice."
   (remove-hook 'find-file-hook #'ocaml-eglot--file-hook)
   (remove-hook 'eglot-managed-mode-hook #'ocaml-eglot--enable-xref-backend t))
 
 ;;;###autoload
-(define-minor-mode ocaml-eglot
+(define-minor-mode ocaml-eglot-mode
   "Minor mode for interacting with `ocaml-lsp-server' using `eglot' as a client.
 OCaml Eglot provides standard implementations of the various custom-requests
  exposed by `ocaml-lsp-server'."
   :lighter " OCaml-eglot"
-  :keymap ocaml-eglot-map
+  :keymap ocaml-eglot-mode-map
   :group 'ocaml-eglot
-  (if ocaml-eglot (ocaml-eglot-setup) (ocaml-eglot-clean)))
+  (if ocaml-eglot-mode (ocaml-eglot--setup) (ocaml-eglot--clean)))
+
+;;;###autoload
+(defalias 'ocaml-eglot #'ocaml-eglot-mode)
+(make-obsolete 'ocaml-eglot 'ocaml-eglot-mode "1.4.0")
+(defalias 'ocaml-eglot-setup #'ocaml-eglot--setup)
+(make-obsolete 'ocaml-eglot-setup 'ocaml-eglot-mode "1.4.0")
+(defvaralias 'ocaml-eglot-hook 'ocaml-eglot-mode-hook)
+(make-obsolete-variable 'ocaml-eglot-hook 'ocaml-eglot-mode-hook "1.4.0")
+(defvaralias 'ocaml-eglot-map 'ocaml-eglot-mode-map)
+(make-obsolete-variable 'ocaml-eglot-map 'ocaml-eglot-mode-map "1.4.0")
 
 (provide 'ocaml-eglot)
 ;;; ocaml-eglot.el ends here


### PR DESCRIPTION
Follow-up on a brief discussion at https://discuss.ocaml.org/t/neocaml-mode-a-modern-emacs-major-mode-for-ocaml-is-looking-for-testers/17807

I strongly feel that if something's a minor mode it should have a proper `-mode` suffix per Emacs conventions. This renames the minor mode from `ocaml-eglot` to `ocaml-eglot-mode` and the keymap from `ocaml-eglot-map` to `ocaml-eglot-mode-map`.

The old names are kept as obsolete aliases so nothing breaks for existing users. I've also made `ocaml-eglot-setup`/`ocaml-eglot-clean` private (`ocaml-eglot--setup`/`ocaml-eglot--clean`) since they're only called internally by the mode toggle and users shouldn't need to deal with them directly.

README examples updated accordingly.