### PR TITLE
Do not prefix message with "[eglot]"

### DIFF
--- a/ocaml-eglot-type-enclosing.el
+++ b/ocaml-eglot-type-enclosing.el
@@ -68,8 +68,8 @@
   "Copy the type of the current enclosing to the Kill-ring."
   (interactive)
   (when ocaml-eglot-type-enclosing-current-type
-    (eglot--message "Copied `%s' to kill-ring"
-                    ocaml-eglot-type-enclosing-current-type)
+    (message (substitute-quotes "Copied `%s' to kill-ring")
+             ocaml-eglot-type-enclosing-current-type)
     (kill-new ocaml-eglot-type-enclosing-current-type)))
 
 (defun ocaml-eglot-type-enclosing--with-fixed-offset (&optional prev-verb)


### PR DESCRIPTION
That causes the output to look substantially uglier, and also is
misleading (the message did not come from Eglot or the language
server---it came from this package instead).